### PR TITLE
Updates serialport dependency to one that installs on 0.12.+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ninja-arduino",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Driver handling communication to the Ninja Blocks arduino cape.",
   "main": "index.js",
   "repository": "",
@@ -17,7 +17,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "serialport": "git://github.com/ninjablocks/node-serialport.git",
+    "serialport": "~2.0.6",
     "through": "~2.2.6"
+  },
+  "engines": {
+    "node": ">=0.10.0"
   }
 }


### PR DESCRIPTION
The dependency on the ninjablocks/node-serialport fork fails to install on nodejs 4.x, and likely would on 0.12.x as well. The 2.0.6 version (currently the latest) works flawlessly with the Ninjablocks Arduino driver, at least under 4.3.x.

Also increments version, and adds minimum nodejs version according to serialport declaration. This is to distinguish from previous version.
