### PR TITLE
Compatibility for Nodejs 6.x

### DIFF
--- a/lib/device-stream.js
+++ b/lib/device-stream.js
@@ -78,12 +78,10 @@ function deviceStream(platform) {
 		if(!path) { return false; }
 		mod.app.opts.deviceHost = undefined;
 		mod.app.opts.devicePath = path;
-		mod.device = new serialport.SerialPort(mod.app.opts.devicePath, {
-
-			parser : serialport.parsers.readline("\n")
-		});
+		mod.device = new serialport(mod.app.opts.devicePath);
 		mod.device.on('open', this.onOpen.bind(this));
-		mod.bindStream(mod.device);
+		const parser = new serialport.parsers.Readline();
+		mod.bindStream(mod.device.pipe(parser));
 		
 		mod.log.debug(
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ninja-arduino",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Driver handling communication to the Ninja Blocks arduino cape.",
   "main": "index.js",
   "repository": "",
@@ -17,7 +17,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "serialport": "git://github.com/ninjablocks/node-serialport.git",
+    "serialport": "~2.0.6",
     "through": "~2.2.6"
+  },
+  "engines": {
+    "node": ">=0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "serialport": "~2.0.6",
+    "serialport": "^6.0.0",
     "through": "~2.2.6"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=6.0.0"
   }
 }


### PR DESCRIPTION
Running under Nodejs 6.x requires upgrading serialport to 6.x.x, which includes API and behavior changes compared to the 2.x.x version usable under Nodejs 0.12.x and up to Nodejs 4.x.